### PR TITLE
use the `keytar` module for cross platform support

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = function randomAccessKeychain(service, account) {
 
   function getPassword(cb) {
     keytar.getPassword(service, account)
-      .then(password => cb(null, Buffer.from(password, 'base64')))
+      .then(password => cb(null, password === null ? null : Buffer.from(password, 'base64')))
       .catch(err => cb(err))
   }
 
@@ -32,7 +32,7 @@ module.exports = function randomAccessKeychain(service, account) {
     },
     write: function(req) {
       getPassword(function(err, existing) {
-        if (existing === undefined) {
+        if (!err && existing == null) {
           const size = req.offset + req.data.length
           const buffer = Buffer.alloc(size)
           req.data.copy(buffer, req.offset)

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const randomAccessStorage = require('random-access-storage')
-const keychain = require('keychain')
+const keytar = require('keytar')
 
 module.exports = function randomAccessKeychain(service, account) {
   if (typeof service !== 'string') throw new Error('service is required')
@@ -8,27 +8,15 @@ module.exports = function randomAccessKeychain(service, account) {
   // We store the password in base64, because we can not store null bytes otherwise.
 
   function getPassword(cb) {
-    keychain.getPassword(
-      {
-        account: account,
-        service: service,
-      },
-      function(err, password) {
-        if (err) return cb(err)
-        cb(null, Buffer.from(password, 'base64'))
-      }
-    )
+    keytar.getPassword(service, account)
+      .then(password => cb(null, Buffer.from(password, 'base64')))
+      .catch(err => cb(err))
   }
 
   function setPassword(buffer, cb) {
-    keychain.setPassword(
-      {
-        account: account,
-        service: service,
-        password: buffer.toString('base64'),
-      },
-      cb
-    )
+    keytar.setPassword(service, account, buffer.toString('base64'))
+      .then(result => cb(null, result))
+      .catch(err => cb(err))
   }
 
   return randomAccessStorage({
@@ -44,7 +32,7 @@ module.exports = function randomAccessKeychain(service, account) {
     },
     write: function(req) {
       getPassword(function(err, existing) {
-        if (err && err.code === 'PasswordNotFound') {
+        if (existing === undefined) {
           const size = req.offset + req.data.length
           const buffer = Buffer.alloc(size)
           req.data.copy(buffer, req.offset)

--- a/package.json
+++ b/package.json
@@ -1,8 +1,7 @@
 {
   "name": "random-access-keychain",
   "version": "1.0.0",
-  "description":
-    "A random-access-storage implementation which stores its contents in the macOS keychain",
+  "description": "A random-access-storage implementation which stores its contents in the system keychain",
   "main": "index.js",
   "scripts": {
     "test": "node test.js"
@@ -18,7 +17,7 @@
   "author": "harry lachenmayer <harrylachenmayer@gmail.com>",
   "license": "ISC",
   "dependencies": {
-    "keychain": "^1.3.0",
+    "keytar": "^6.0.1",
     "random-access-storage": "^1.1.1"
   },
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -22,7 +22,7 @@ test('write and read', function(t) {
 test('read before write', function(t) {
   const storage = rak('random-access-keychain-test', 'does-not-exist')
   storage.read(0, 1, function(err, password) {
-    t.is(err.code, 'PasswordNotFound')
+    t.is(password, undefined)
     t.end()
   })
 })


### PR DESCRIPTION
I swapped out the `keychain` module for `keytar`, which is maintained by the atom team and has support for MacOS, Linux and Windows.

Tests pass for me on Linux!